### PR TITLE
fix compilation with Centos 5.8

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -23,6 +23,8 @@ list(REMOVE_ITEM files
   ${FOLLY_DIR}/build/GenerateFingerprintTables.cpp
   ${FOLLY_DIR}/detail/Clock.cpp
   ${FOLLY_DIR}/detail/Futex.cpp
+  ${FOLLY_DIR}/LifoSem.cpp
+  ${FOLLY_DIR}/detail/MemoryIdler.cpp
   ${FOLLY_DIR}/experimental/File.cpp
   ${FOLLY_DIR}/experimental/exception_tracer/ExceptionTracer.cpp
   ${FOLLY_DIR}/experimental/exception_tracer/ExceptionTracerBenchmark.cpp
@@ -44,8 +46,6 @@ list(REMOVE_ITEM files
 # Remove non-portable items
 if (NOT LINUX)
   list(REMOVE_ITEM files
-    ${FOLLY_DIR}/LifoSem.cpp
-    ${FOLLY_DIR}/detail/MemoryIdler.cpp
     ${FOLLY_DIR}/experimental/symbolizer/Symbolizer.cpp
     ${FOLLY_DIR}/experimental/symbolizer/Dwarf.cpp
     ${FOLLY_DIR}/experimental/symbolizer/Elf.cpp


### PR DESCRIPTION
LifoSem and MemoryIdler use folly/detail/Futex.h (Futex had been disabled already) that don't compile at Centos 5.8 - Linux 2.6.18 , because FUTEX_WAIT_BITSET, FUTEX_WAKE_BITSET, FUTEX_CLOCK_REALTIME aren't defined
