### PR TITLE
fix compilation with Centos 5.8

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -41,6 +41,7 @@ list(REMOVE_ITEM files
   ${FOLLY_DIR}/io/async/AsyncTimeout.cpp
   ${FOLLY_DIR}/io/async/EventBase.cpp
   ${FOLLY_DIR}/io/async/Request.cpp
+  ${FOLLY_DIR}/wangle/ThreadGate.cpp
   )
 
 # Remove non-portable items


### PR DESCRIPTION
wangle/ThreadGate depends at folly/detail/Futex.h and isn't used in hhvm
while folly/detail/Futex.h doesn't compiles with Centos 5.8 - Linux 2.6.18 , because FUTEX_WAIT_BITSET, FUTEX_WAKE_BITSET, FUTEX_CLOCK_REALTIME aren't defined
