### PR TITLE
Defer evaluation of CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ function(TP_INSTALL_HEADERS TARGET SRCDIR DEST)
     CODE "INCLUDE(\"${HPHP_HOME}/CMake/HPHPFunctions.cmake\")
       HHVM_INSTALL_HEADERS(${TARGET}
       \"${CMAKE_CURRENT_SOURCE_DIR}/${SRCDIR}\"
-      \"${CMAKE_INSTALL_PREFIX}/include/hphp/third-party/${DEST}\"
+      \"\${CMAKE_INSTALL_PREFIX}/include/hphp/third-party/${DEST}\"
       ${files})"
     COMPONENT dev)
 endfunction()


### PR DESCRIPTION
Per https://github.com/facebook/hhvm/issues/2765. This change should not be needed to close the bug, but it's probably a good idea.
