### PR TITLE
don't build unnecessary fastlz objects

### DIFF
--- a/fastlz/CMakeLists.txt
+++ b/fastlz/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(fastlz STATIC fastlz.c 6unpack.c 6pack.c)
+add_library(fastlz STATIC fastlz.c)


### PR DESCRIPTION
These 2 stand-alone utilities are not used by HHVM and they define a
main() that may cause certain linkers to complain about duplicate
symbols:

Linking CXX executable hhvm
duplicate symbol _main in:
    CMakeFiles/hhvm.dir/main.cpp.o
    ../../third-party/fastlz/libfastlz.a(6unpack.c.o)
duplicate symbol _usage in:
    ../../third-party/fastlz/libfastlz.a(6unpack.c.o)
    ../../third-party/fastlz/libfastlz.a(6pack.c.o)
duplicate symbol _detect_magic in:
    ../../third-party/fastlz/libfastlz.a(6unpack.c.o)
    ../../third-party/fastlz/libfastlz.a(6pack.c.o)
duplicate symbol _main in:
    CMakeFiles/hhvm.dir/main.cpp.o
    ../../third-party/fastlz/libfastlz.a(6pack.c.o)
ld: 4 duplicate symbols for architecture x86_64
