### PR TITLE
change reference from gettime to clock_gettime

### DIFF
--- a/thrift/lib/cpp/portability.h
+++ b/thrift/lib/cpp/portability.h
@@ -33,7 +33,7 @@ class Timer {
 public:
   static void GetMonotonicTime(timespec &ts) {
     #ifndef __APPLE__
-      gettime(CLOCK_MONOTONIC, &ts);
+      clock_gettime(CLOCK_MONOTONIC, &ts);
     #else
       struct timeval tv;
       gettimeofday(&tv, nullptr);


### PR DESCRIPTION
This was incorrectly copied from HHVM's timer.cpp. There is no such
function as gettime in the C library.
