### PR TITLE
Replace C++11 TR1 references from Thrift code with their non-prefixed equivalents

### DIFF
--- a/thrift/lib/cpp/async/TEventBase.h
+++ b/thrift/lib/cpp/async/TEventBase.h
@@ -22,14 +22,14 @@
 #include <utility>
 #include <boost/intrusive/list.hpp>
 #include <boost/utility.hpp>
-#include <tr1/functional>
+#include <functional>
 #include <event.h>  // libevent
 #include <errno.h>
 #include <math.h>
 
 namespace apache { namespace thrift { namespace async {
 
-typedef std::tr1::function<void()> Cob;
+typedef std::function<void()> Cob;
 template <typename MessageT>
 class TNotificationQueue;
 
@@ -407,7 +407,7 @@ class TEventBase : private boost::noncopyable, public TimeoutManager {
 
   // --------- libevent callbacks (not for client use) ------------
 
-  static void runTr1FunctionPtr(std::tr1::function<void()>* fn);
+  static void runTr1FunctionPtr(std::function<void()>* fn);
 
   // small object used as a callback arg with enough info to execute the
   // appropriate client-provided Cob

--- a/thrift/lib/cpp/concurrency/ThreadManager.h
+++ b/thrift/lib/cpp/concurrency/ThreadManager.h
@@ -21,7 +21,7 @@
 #define HPHP_THRIFT_CONCURRENCY_THREADMANAGER_H 1
 
 #include <memory>
-#include <tr1/functional>
+#include <functional>
 #include <sys/types.h>
 #include <array>
 #include <unistd.h>
@@ -55,8 +55,8 @@ class ThreadManager {
 
  public:
   class Task;
-  typedef std::tr1::function<void(std::shared_ptr<Runnable>)> ExpireCallback;
-  typedef std::tr1::function<void()> InitCallback;
+  typedef std::function<void(std::shared_ptr<Runnable>)> ExpireCallback;
+  typedef std::function<void()> InitCallback;
 
   virtual ~ThreadManager() {}
 


### PR DESCRIPTION
As requested on https://github.com/hhvm/hhvm-third-party/issues/18
