### PR TITLE
Thrift: fix wrong strerror_r declaration on OS X

### DIFF
--- a/thrift/lib/cpp/config.h
+++ b/thrift/lib/cpp/config.h
@@ -263,7 +263,9 @@
 #define STDC_HEADERS 1
 
 /* Define to 1 if strerror_r returns char *. */
-#define STRERROR_R_CHAR_P 1
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE)
+  #define STRERROR_R_CHAR_P 1
+#endif
 
 /* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
 #define TIME_WITH_SYS_TIME 1


### PR DESCRIPTION
This is using the same check as Folly is doing in String.cpp
