### PR TITLE
remove a file from the folly build

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -23,6 +23,7 @@ list(REMOVE_ITEM files
   ${FOLLY_DIR}/build/GenerateFingerprintTables.cpp
   ${FOLLY_DIR}/detail/Clock.cpp
   ${FOLLY_DIR}/detail/Futex.cpp
+  ${FOLLY_DIR}/detail/FunctionalExcept.cpp
   ${FOLLY_DIR}/LifoSem.cpp
   ${FOLLY_DIR}/detail/MemoryIdler.cpp
   ${FOLLY_DIR}/experimental/File.cpp


### PR DESCRIPTION
The functions defined here conflict with things built in to libstdc++.

Since we don't use this file in HHVM anyway, removing this prevents
duplicate symbols when statically linking.
