### PR TITLE
Don't remove compilation of FunctionalExcept.cpp on libc++

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -23,7 +23,6 @@ list(REMOVE_ITEM files
   ${FOLLY_DIR}/build/GenerateFingerprintTables.cpp
   ${FOLLY_DIR}/detail/Clock.cpp
   ${FOLLY_DIR}/detail/Futex.cpp
-  ${FOLLY_DIR}/detail/FunctionalExcept.cpp
   ${FOLLY_DIR}/LifoSem.cpp
   ${FOLLY_DIR}/detail/MemoryIdler.cpp
   ${FOLLY_DIR}/experimental/File.cpp
@@ -44,6 +43,13 @@ list(REMOVE_ITEM files
   ${FOLLY_DIR}/io/async/Request.cpp
   ${FOLLY_DIR}/wangle/ThreadGate.cpp
   )
+
+check_include_file(INCLUDE "bits/functexcept.h" VARIABLE functexcept_present)
+if (functexcept_present)
+  list(REMOVE_ITEM files
+    ${FOLLY_DIR}/detail/FunctionalExcept.cpp
+  )
+endif()
 
 # Remove non-portable items
 if (NOT LINUX)


### PR DESCRIPTION
Non-stdc++ platforms don't have bits/functexcept.h, so do compile FunctionalExcept.cpp on those.
