### PR TITLE
make libafdt forward compatible with glibc >=2.20

### DIFF
--- a/libafdt/src/async.c
+++ b/libafdt/src/async.c
@@ -1,6 +1,7 @@
 // libevent needs this for u_char
-#define _BSD_SOURCE
-
+// _BSD_SOURCE is deprecated in glibc 2.20
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #include <stdlib.h>
 #include <errno.h>
 #include <assert.h>

--- a/libafdt/test/catter.c
+++ b/libafdt/test/catter.c
@@ -10,7 +10,9 @@
    an EOF on stdin and finishes writing everything to the remote stdout.
  */
 
-#define _BSD_SOURCE
+// _BSD_SOURCE is deprecated in glibc 2.20
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #define _XOPEN_SOURCE
 #include <stdbool.h>
 #include <stdlib.h>

--- a/libafdt/test/server.c
+++ b/libafdt/test/server.c
@@ -15,7 +15,9 @@
      /close_prod:  Close the production socket.
  */
 
-#define _BSD_SOURCE
+// _BSD_SOURCE is deprecated in glibc 2.20
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #define _XOPEN_SOURCE
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
_BSD_SOURCE is deprecated in glibc 2.2.0. _DEFAULT_SOURCE
fulfills all interfaces _BSD_SOURCE did.

See https://sourceware.org/glibc/wiki/Release/2.20#Packaging_Changes
for details.

It suggests removing them and testing if it builds without it.
It does, but i have a pretty recent libevent.

The comment in src/async says that _BSD_SOURCE was added on
purpose due to a missing u_char, though.