### PR TITLE
Libmbfl compile error when building from hhvm

### DIFF
--- a/libmbfl/CMakeLists.txt
+++ b/libmbfl/CMakeLists.txt
@@ -31,7 +31,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_SOURCE
 
 add_definitions(-DHAVE_CONFIG_H=1)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbfl)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/nls)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/filters)


### PR DESCRIPTION
When compiling 3.6 and latest hhvm it tries to use config.h from mcrouter include path. This fix it.