### PR TITLE
context lib need to boost library 1.51.0 above

### DIFF
--- a/mcrouter/CMakeLists.txt
+++ b/mcrouter/CMakeLists.txt
@@ -25,7 +25,7 @@ add_definitions(-DNO_LIB_GFLAGS)
 add_definitions(-DLIBMC_FBTRACE_DISABLE)
 add_definitions(-DHAVE_CONFIG_H)
 
-find_package(Boost 1.48.0 COMPONENTS context regex system filesystem REQUIRED)
+find_package(Boost 1.51.0 COMPONENTS context regex system filesystem REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 


### PR DESCRIPTION
Now the library requirement is 1.48,but the compile hhvm will can't find the context library,because the context library in 1.51.0 above.
Summary:
http://www.boost.org/users/history/version_1_51_0.html