### PR TITLE
Removed the symbolic links, because they don't work on windows

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(FOLLY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/folly")
+set(FOLLY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/folly")
 
 # Ensure that we are either getting malloc functions
 # like malloc_usable_size() from either malloc.h

--- a/folly/folly
+++ b/folly/folly
@@ -1,1 +1,0 @@
-src/folly

--- a/mcrouter/CMakeLists.txt
+++ b/mcrouter/CMakeLists.txt
@@ -1,5 +1,7 @@
+set(MCROUTER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/mcrouter")
+
 set(C_SOURCES)
-auto_sources(files "*.c" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter")
+auto_sources(files "*.c" "RECURSE" "${MCROUTER_DIR}")
 foreach (file ${files})
   if (${file} MATCHES "/(test|examples)/")
     list(REMOVE_ITEM files ${file})
@@ -13,15 +15,15 @@ list(APPEND C_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/ascii_client.c")
 list(APPEND C_SOURCES ${files})
 
 set(CXX_SOURCES)
-auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter")
+auto_sources(files "*.cpp" "RECURSE" "${MCROUTER_DIR}")
 foreach (file ${files})
   if (${file} MATCHES "(/(test|examples)/|Test.cpp$)")
     list(REMOVE_ITEM files ${file})
   endif()
 endforeach()
-# McAsciiParser-gen.cpp is generated from mcrouter/lib/network/McAsciiParser.rl
+# McAsciiParser-gen.cpp is generated from ${MCROUTER_DIR}/lib/network/McAsciiParser.rl
 # using ragel
-# So ran the command found in mcrouter/Makefile.am manually and put the file
+# So ran the command found in ${MCROUTER_DIR}/Makefile.am manually and put the file
 # here -- this avoids linking errors
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/McAsciiParser-gen.cpp")
 list(APPEND CXX_SOURCES ${files})
@@ -36,7 +38,7 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 include_directories("${HPHP_HOME}/third-party")
 include_directories("${HPHP_HOME}/third-party/mcrouter/")
-#include_directories("${HPHP_HOME}/third-party/mcrouter/mcrouter/lib/fbi")
+#include_directories("${MCROUTER_DIR}/lib/fbi")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
 add_library(mcrouter STATIC ${C_SOURCES} ${CXX_SOURCES})
 target_link_libraries(mcrouter folly ${Boost_LIBRARIES})

--- a/mcrouter/mcrouter
+++ b/mcrouter/mcrouter
@@ -1,1 +1,0 @@
-src/mcrouter

--- a/proxygen/CMakeLists.txt
+++ b/proxygen/CMakeLists.txt
@@ -1,5 +1,8 @@
+set(PROXYGEN_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/proxygen/lib")
+set(PROXYGEN_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/proxygen/external")
+
 set(CXX_SOURCES)
-auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+auto_sources(files "*.cpp" "RECURSE" "${PROXYGEN_LIB_DIR}")
 foreach (file ${files})
   if (${file} MATCHES "/test/")
     list(REMOVE_ITEM files ${file})
@@ -9,17 +12,17 @@ foreach (file ${files})
   endif()
 endforeach()
 list(APPEND CXX_SOURCES ${files})
-list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/external/http_parser/http_parser_cpp.cpp")
-list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.cpp")
-list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.h")
+list(APPEND CXX_SOURCES "${PROXYGEN_EXTERNAL_DIR}/http_parser/http_parser_cpp.cpp")
+list(APPEND CXX_SOURCES "${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.cpp")
+list(APPEND CXX_SOURCES "${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.h")
 
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.h
-  COMMAND HEADERS_LIST=${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.txt FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.. INSTALL_DIR=${CMAKE_CURRENT_SOURCE_DIR}/lib/http ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/gen_HTTPCommonHeaders.h.sh
+  OUTPUT ${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.h
+  COMMAND HEADERS_LIST=${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.txt FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.. INSTALL_DIR=${PROXYGEN_LIB_DIR}/http ${PROXYGEN_LIB_DIR}/http/gen_HTTPCommonHeaders.h.sh
 )
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.cpp
-  COMMAND HEADERS_LIST=${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.txt FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.. INSTALL_DIR=${CMAKE_CURRENT_SOURCE_DIR}/lib/http ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/gen_HTTPCommonHeaders.cpp.sh
+  OUTPUT ${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.cpp
+  COMMAND HEADERS_LIST=${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.txt FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.. INSTALL_DIR=${PROXYGEN_LIB_DIR}/http ${PROXYGEN_LIB_DIR}/http/gen_HTTPCommonHeaders.cpp.sh
 )
 
 add_definitions(-DNO_LIB_GFLAGS)

--- a/proxygen/external
+++ b/proxygen/external
@@ -1,1 +1,0 @@
-src/proxygen/external

--- a/proxygen/lib
+++ b/proxygen/lib
@@ -1,1 +1,0 @@
-src/proxygen/lib

--- a/squangle/CMakeLists.txt
+++ b/squangle/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 2.8.0)
+set(SQUANGLE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/squangle")
+
 project(squangle CXX C)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
-auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/squangle")
+auto_sources(files "*.cpp" "RECURSE" "${SQUANGLE_DIR}")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${RE2_INCLUDE_DIR} ${MYSQL_INCLUDE_DIR})
 add_library(squangle STATIC ${files})
 add_dependencies(squangle webscalesqlclient)

--- a/squangle/squangle
+++ b/squangle/squangle
@@ -1,1 +1,0 @@
-src/squangle

--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(THRIFT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/thrift")
+set(THRIFT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/thrift")
 
 set(CXX_SOURCES)
 

--- a/thrift/thrift
+++ b/thrift/thrift
@@ -1,1 +1,0 @@
-src/thrift/


### PR DESCRIPTION
The symlinks used in the folly, mcrouter, proxygen, squangle, and thrift CMake files don't get checked out as symlinks on windows, instead they are just text files. This removes the need for the symlinks entirely, and removes the symlinks as well.
