### PR TITLE
Fix webscalesqlclient CMakeLists no download info issue

### DIFF
--- a/re2/CMakeLists.txt
+++ b/re2/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.0)
 project(re2 CXX C)
 
+add_definitions(-Wno-narrowing)
+
 auto_sources(sources "*.cc" RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/src/re2")
 SET(util_sources
   src/util/arena.cc

--- a/webscalesqlclient/CMakeLists.txt
+++ b/webscalesqlclient/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.0)
 include(ExternalProject)
 ExternalProject_Add(
   webscalesqlclient
+  URL file://${CMAKE_CURRENT_SOURCE_DIR}/webscalesql-5.6
   SOURCE_DIR webscalesql-5.6/
   CMAKE_ARGS
   -DWITHOUT_SERVER=TRUE

--- a/webscalesqlclient/src
+++ b/webscalesqlclient/src
@@ -1,1 +1,1 @@
-webscalesql-5.6/
+../../build/third-party/webscalesqlclient/webscalesql-5.6


### PR DESCRIPTION
CMake: 3.2.2
ArchLinux: 4.0.4-2-ARCH ... x86_64 GNU/Linux

```
CMake Error at /usr/share/cmake-3.2/Modules/ExternalProject.cmake:1850 (message):
  error: no download info for 'webscalesqlclient' -- please specify
  existing/non-empty SOURCE_DIR or one of URL, CVS_REPOSITORY and CVS_MODULE,
  SVN_REPOSITORY, GIT_REPOSITORY, HG_REPOSITORY or DOWNLOAD_COMMAND
```