### PR TITLE
Add boost 'context' library to Folly CMake list

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -91,7 +91,7 @@ list(REMOVE_ITEM files ${FOLLY_DIR}/io/Compression.cpp)
 add_library(folly STATIC ${files} ${genfiles} ${cfiles} )
 
 find_package(Boost 1.48.0 COMPONENTS system program_options filesystem regex
-             REQUIRED)
+             context REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 

--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -90,7 +90,7 @@ list(REMOVE_ITEM files ${FOLLY_DIR}/io/Compression.cpp)
 
 add_library(folly STATIC ${files} ${genfiles} ${cfiles} )
 
-find_package(Boost 1.48.0 COMPONENTS system program_options filesystem regex
+find_package(Boost 1.51.0 COMPONENTS system program_options filesystem regex
              context REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})


### PR DESCRIPTION
The Boost 'context' library is now required to compile folly in
the version checked out here. The context library is required in the
file folly/experimental/fibers/BoostContextCompatibility.h.