### PR TITLE
Remove folly and thrift's dependence on symlinks

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(FOLLY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/folly")
+set(FOLLY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/folly")
 
 # Ensure that we are either getting malloc functions
 # like malloc_usable_size() from either malloc.h

--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(THRIFT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/thrift")
+set(THRIFT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/thrift")
 
 set(CXX_SOURCES)
 


### PR DESCRIPTION
Because, without some massive pains, the symlinks don't translate nicely on windows.
This doesn't remove the actual symlinks yet.