### PR TITLE
Add headers to the libraries

### DIFF
--- a/double-conversion/CMakeLists.txt
+++ b/double-conversion/CMakeLists.txt
@@ -1,2 +1,7 @@
-auto_sources(files "*.cc" "${CMAKE_CURRENT_SOURCE_DIR}/src/double-conversion")
-add_library(double-conversion STATIC ${files})
+auto_sources(CXX_SOURCES "*.cc" "${CMAKE_CURRENT_SOURCE_DIR}/src/double-conversion")
+auto_sources(HEADER_SOURCES "*.h" "${CMAKE_CURRENT_SOURCE_DIR}/src/double-conversion")
+add_library(double-conversion STATIC ${CXX_SOURCES} ${HEADER_SOURCES})
+auto_source_group("double-conversion"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/double-conversion"
+  ${CXX_SOURCES} ${HEADER_SOURCES}
+)

--- a/fastlz/CMakeLists.txt
+++ b/fastlz/CMakeLists.txt
@@ -1,1 +1,2 @@
-add_library(fastlz STATIC fastlz.c)
+add_library(fastlz STATIC fastlz.c fastlz.h)
+auto_source_group("fastlz" "${CMAKE_CURRENT_SOURCE_DIR}" fastlz.c fastlz.h)

--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -30,19 +30,11 @@ auto_sources(genfiles "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/gen")
 # Main folly library files
 auto_sources(files "*.cpp" "RECURSE" "${FOLLY_DIR}")
 auto_sources(cfiles "*.c" "RECURSE" "${FOLLY_DIR}")
+auto_sources(hfiles "*.h" "RECURSE" "${FOLLY_DIR}")
 
 # No need for tests, Benchmarks, Utils, or most experimental stuff
-foreach (file ${files})
-  if (${file} MATCHES "/test/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "Test.cpp$")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/futures/exercises/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-endforeach()
+HHVM_REMOVE_MATCHES_FROM_LISTS(files cfiles hfiles
+  MATCHES "/test/" "Test.cpp$" "/futures/exercises/")
 list(REMOVE_ITEM files
   ${FOLLY_DIR}/Benchmark.cpp
   ${FOLLY_DIR}/build/GenerateFingerprintTables.cpp
@@ -86,7 +78,9 @@ endif()
 # Don't add dep until we need it
 list(REMOVE_ITEM files ${FOLLY_DIR}/io/Compression.cpp)
 
-add_library(folly STATIC ${files} ${genfiles} ${cfiles} )
+add_library(folly STATIC ${files} ${genfiles} ${cfiles} ${hfiles})
+auto_source_group("folly" "${FOLLY_DIR}"
+  ${files} ${genfiles} ${cfiles} ${hfiles})
 
 find_package(Boost 1.51.0 COMPONENTS system program_options filesystem regex
              context REQUIRED)

--- a/proxygen/CMakeLists.txt
+++ b/proxygen/CMakeLists.txt
@@ -1,14 +1,11 @@
 set(CXX_SOURCES)
+set(HEADER_SOURCES)
 auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/lib")
-foreach (file ${files})
-  if (${file} MATCHES "/test/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/lib/utils/(Null)?TraceEvent")
-    list(REMOVE_ITEM files ${file})
-  endif()
-endforeach()
+auto_sources(hfiles "*.h" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+HHVM_REMOVE_MATCHES_FROM_LISTS(files hfiles
+  MATCHES "/test/" "/lib/utils/(Null)?TraceEvent")
 list(APPEND CXX_SOURCES ${files})
+list(APPEND HEADER_SOURCES ${hfiles})
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/external/http_parser/http_parser_cpp.cpp")
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.cpp")
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.h")
@@ -30,7 +27,9 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 include_directories("${HPHP_HOME}/third-party")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
-add_library(hphp_proxygen STATIC ${CXX_SOURCES})
+add_library(hphp_proxygen STATIC ${CXX_SOURCES} ${HEADER_SOURCES})
+auto_source_group("hphp_proxygen" "${CMAKE_CURRENT_SOURCE_DIR}/src/proxygen"
+  ${CXX_SOURCES} ${HEADER_SOURCES})
 target_link_libraries(hphp_proxygen wangle ${Boost_LIBRARIES}
                                            ${LIBGLOG_LIBRARY}
                                            ${LIBPTHREAD_LIBRARIES})

--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -1,50 +1,16 @@
 set(THRIFT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/thrift")
 
 set(CXX_SOURCES)
-
+set(HEADER_SOURCES)
 auto_sources(files "*.cpp" "RECURSE" "${THRIFT_DIR}")
-
-foreach (file ${files})
-  if (${file} MATCHES "/perf/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/test/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/tests/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/cpp2/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/lib/d/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/lib/node/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/lib/py/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/lib/php/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/tutorial/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/example/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "Test.cpp")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/neutronium/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/protocol/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-endforeach()
+auto_sources(hfiles "*.h" "RECURSE" "${THRIFT_DIR}")
+HHVM_REMOVE_MATCHES_FROM_LISTS(files hfiles MATCHES
+  "/perf/" "/test/" "/tests/"
+  "/cpp2/" "/lib/d/" "/lib/node/"
+  "/lib/py/" "/lib/php/" "/tutorial/"
+  "/example/" "Test.cpp" "/neutronium/"
+  "/protocol/"
+)
 
 list(REMOVE_ITEM files
   ${THRIFT_DIR}/contrib/thrift_dump.cpp
@@ -60,7 +26,21 @@ list(REMOVE_ITEM files
   ${THRIFT_DIR}/lib/cpp/util/TNonblockingServerCreator.cpp
 )
 
+list(REMOVE_ITEM hfiles
+  ${THRIFT_DIR}/lib/cpp/transport/HDFS.h
+  ${THRIFT_DIR}/lib/cpp/transport/THDFSFileTransport.h
+  ${THRIFT_DIR}/lib/cpp/transport/THeaderTransport.h
+  ${THRIFT_DIR}/lib/cpp/transport/TMemPagedTransport.h
+  ${THRIFT_DIR}/lib/cpp/transport/TMemPagedFactory.h
+  ${THRIFT_DIR}/lib/cpp/transport/THeader.h
+  ${THRIFT_DIR}/lib/cpp/protocol/TSimpleJSONProtocol.h
+  ${THRIFT_DIR}/lib/cpp/concurrency/NumaThreadManager.h
+  ${THRIFT_DIR}/lib/cpp/util/TThreadedServerCreator.h
+  ${THRIFT_DIR}/lib/cpp/util/TNonblockingServerCreator.h
+)
+
 list(APPEND CXX_SOURCES ${files})
+list(APPEND HEADER_SOURCES ${hfiles})
 
 add_definitions(-DNO_LIB_GFLAGS)
 
@@ -70,8 +50,9 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 include_directories("${HPHP_HOME}/third-party")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
-add_library(hphp_thrift STATIC ${CXX_SOURCES})
-
+add_library(hphp_thrift STATIC ${CXX_SOURCES} ${HEADER_SOURCES})
+auto_source_group("hphp_thrift" "${THRIFT_DIR}/lib/cpp"
+  ${CXX_SOURCES} ${HEADER_SOURCES})
 target_link_libraries(hphp_thrift wangle ${Boost_LIBRARIES}
                                          ${LIBGLOG_LIBRARY}
                                          ${LIBPTHREAD_LIBRARIES})

--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -24,26 +24,18 @@ endif()
 
 # Main wangle library files
 auto_sources(files "*.cpp" "RECURSE" "${WANGLE_DIR}")
+auto_sources(hfiles "*.h" "RECURSE" "${WANGLE_DIR}")
 
-# No need for tests, Benchmarks, Utils, or most experimental stuff
-foreach (file ${files})
-  if (${file} MATCHES "/test/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "Test.cpp$")
-    list(REMOVE_ITEM files ${file})
-  endif()
-  if (${file} MATCHES "/example/")
-    list(REMOVE_ITEM files ${file})
-  endif()
-endforeach()
+HHVM_REMOVE_MATCHES_FROM_LISTS(files hfiles MATCHES
+  "/test/" "Test.cpp$" "/example/")
 
 list(REMOVE_ITEM files
   ${WANGLE_DIR}/bootstrap/ServerBootstrap.cpp
   ${WANGLE_DIR}/channel/FileRegion.cpp
 )
 
-add_library(wangle STATIC ${files})
+add_library(wangle STATIC ${files} ${hfiles})
+auto_source_group("wangle" "${WANGLE_DIR}" ${files} ${hfiles})
 
 find_package(Boost 1.51.0 COMPONENTS system thread REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
DO NOT MERGE! - This is currently broken due to some changes I made while separating this out of my main build.

This also switches to `HHVM_REMOVE_MATCHES_FROM_LISTS`, and adds `auto_source_group` calls as well.

This was done as a single commit because they would end up conflicting with each other or else need to be updated after one is merged.