### PR TITLE
Allow building libmbfl on Windows

### DIFF
--- a/libmbfl/mbfl/CMakeLists.txt
+++ b/libmbfl/mbfl/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(mbfl STATIC ${mbfl_files} ${mbfl_filters_files} ${mbfl_nls_files})
 add_custom_target(
   eaw_table
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/mk_eaw_tbl.awk" "${CMAKE_CURRENT_SOURCE_DIR}/EastAsianWidth.txt"
-  COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/generate-eaw-table.sh ${AWK_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR} 
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate-eaw-table.sh ${AWK_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}
 )
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/eaw_table.h")
 add_dependencies(mbfl eaw_table)

--- a/libmbfl/mbfl/mk_eaw_tbl.awk
+++ b/libmbfl/mbfl/mk_eaw_tbl.awk
@@ -5,6 +5,49 @@
 # Description: a script to generate east asian width table.
 #
 
+# We pull in strtonum from the mingw install so that we can
+# run under the version of awk included in msysgit.
+
+# This function is under the following license:
+# Arnold Robbins, arnold@skeeve.com, Public Domain
+# February, 2004
+function strtonum(str, ret, chars, n, i, k, c)
+{
+    if (str ~ /^0[0-7]*$/) {
+        # octal
+        n = length(str)
+        ret = 0
+        for (i = 1; i <= n; i++) {
+            c = substr(str, i, 1)
+            if ((k = index("01234567", c)) > 0)
+                k-- # adjust for 1-basing in awk
+
+            ret = ret * 8 + k
+        }
+    } else if (str ~ /^0[xX][0-9a-fA-f]+/) {
+        # hexadecimal
+        str = substr(str, 3)    # lop off leading 0x
+        n = length(str)
+        ret = 0
+        for (i = 1; i <= n; i++) {
+            c = substr(str, i, 1)
+            c = tolower(c)
+            if ((k = index("0123456789", c)) > 0)
+                k-- # adjust for 1-basing in awk
+            else if ((k = index("abcdef", c)) > 0)
+                k += 9
+
+            ret = ret * 16 + k
+        }
+    } else if (str ~ /^[-+]?([0-9]+([.][0-9]*([Ee][0-9]+)?)?|([.][0-9]+([Ee][-+]?[0-9]+)?))$/) {
+        # decimal number, possibly floating point
+        ret = str + 0
+    } else
+        ret = "NOT-A-NUMBER"
+
+    return ret
+}
+
 BEGIN {
 	prev = -1
 	comma = 0

--- a/libmbfl/mbfl/mk_eaw_tbl.awk
+++ b/libmbfl/mbfl/mk_eaw_tbl.awk
@@ -5,49 +5,6 @@
 # Description: a script to generate east asian width table.
 #
 
-# We pull in strtonum from the mingw install so that we can
-# run under the version of awk included in msysgit.
-
-# This function is under the following license:
-# Arnold Robbins, arnold@skeeve.com, Public Domain
-# February, 2004
-function strtonum(str, ret, chars, n, i, k, c)
-{
-    if (str ~ /^0[0-7]*$/) {
-        # octal
-        n = length(str)
-        ret = 0
-        for (i = 1; i <= n; i++) {
-            c = substr(str, i, 1)
-            if ((k = index("01234567", c)) > 0)
-                k-- # adjust for 1-basing in awk
-
-            ret = ret * 8 + k
-        }
-    } else if (str ~ /^0[xX][0-9a-fA-f]+/) {
-        # hexadecimal
-        str = substr(str, 3)    # lop off leading 0x
-        n = length(str)
-        ret = 0
-        for (i = 1; i <= n; i++) {
-            c = substr(str, i, 1)
-            c = tolower(c)
-            if ((k = index("0123456789", c)) > 0)
-                k-- # adjust for 1-basing in awk
-            else if ((k = index("abcdef", c)) > 0)
-                k += 9
-
-            ret = ret * 16 + k
-        }
-    } else if (str ~ /^[-+]?([0-9]+([.][0-9]*([Ee][0-9]+)?)?|([.][0-9]+([Ee][-+]?[0-9]+)?))$/) {
-        # decimal number, possibly floating point
-        ret = str + 0
-    } else
-        ret = "NOT-A-NUMBER"
-
-    return ret
-}
-
 BEGIN {
 	prev = -1
 	comma = 0


### PR DESCRIPTION
The first thing this does is remove the explicit call to `sh`, because all that does is break things on Windows.
The second thing we do is inline the definition of strtonum from awk (which is public domain), to allow running the script under the version of awk provided by msysgit.