### PR TITLE
Don't allow a custom path for LIBMBFL_LIBRARY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(THIRD_PARTY_MODULES)
 set(THIRD_PARTY_HEADERS)
 
 list(APPEND THIRD_PARTY_MODULES
+  libmbfl
   timelib
   folly
   wangle
@@ -36,11 +37,6 @@ endif()
 # Add bundled libafdt if the system one will not be used
 if(NOT LIBAFDT_LIBRARY)
   list(APPEND THIRD_PARTY_MODULES libafdt)
-endif()
-
-# Add bundled libmbfl if the system one will not be used
-if(NOT LIBMBFL_LIBRARY)
-  list(APPEND THIRD_PARTY_MODULES libmbfl)
 endif()
 
 if(ENABLE_ASYNC_MYSQL)


### PR DESCRIPTION
The core of HHVM unconditionally links directly against the mbfl target, so we can't allow it to be excluded from building.
Technically, the afdt is the same way, but as doing that change here will conflict with the next PR I'm about to open, I've not touched it as part of this PR.