### PR TITLE
Don't build libafdt under MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,7 @@ if(ENABLE_FASTCGI)
   list(APPEND THIRD_PARTY_MODULES thrift)
 endif()
 
-# Add bundled libafdt if the system one will not be used
-if(NOT LIBAFDT_LIBRARY)
+if (NOT MSVC)
   list(APPEND THIRD_PARTY_MODULES libafdt)
 endif()
 


### PR DESCRIPTION
Because this would be a nightmare to port, and is only needed for the takeover agent, which I'll disable under MSVC in a future PR.
This also disables the ability to set a custom path for libafdt, for the reasons outlined in #78.