### PR TITLE
Allow building libmbfl as static under windows

### DIFF
--- a/libmbfl/mbfl/CMakeLists.txt
+++ b/libmbfl/mbfl/CMakeLists.txt
@@ -9,6 +9,7 @@ SET(mbfl_files mbfilter.c mbfl_string.c mbfl_language.c mbfl_encoding.c mbfl_con
 mbfl_ident.c mbfl_memory_device.c mbfl_allocators.c mbfl_filter_output.c
 mbfilter_pass.c mbfilter_wchar.c mbfilter_8bit.c)
 
+add_definitions("-DMBFL_STATIC")
 add_library(mbfl STATIC ${mbfl_files} ${mbfl_filters_files} ${mbfl_nls_files})
 
 # Generate eaw_table.h

--- a/libmbfl/mbfl/mbfl_defs.h
+++ b/libmbfl/mbfl/mbfl_defs.h
@@ -40,11 +40,15 @@
 #endif 
 
 #ifdef WIN32
+#ifdef MBFL_STATIC
+#define MBFLAPI
+#else
 #ifdef MBFL_DLL_EXPORT
 #define MBFLAPI __declspec(dllexport)
 #else
 #define MBFLAPI __declspec(dllimport)
 #endif /* MBFL_DLL_EXPORT */
+#endif
 #else
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define MBFLAPI __attribute__((visibility("default")))


### PR DESCRIPTION
We build libmbfl as a static library, but the headers don't currently realize that, and declare everything with dllexport or dllimport, as if we'd built a dynamic library.
This adds a small adjustment in a header, and adds a definition to ensure it's used when we build mbfl.