### PR TITLE
Use a static assert rather than a crazy typedef

### DIFF
--- a/double-conversion/src/double-conversion/utils.h
+++ b/double-conversion/src/double-conversion/utils.h
@@ -295,10 +295,7 @@ class StringBuilder {
 // another thus avoiding the warning.
 template <class Dest, class Source>
 inline Dest BitCast(const Source& source) {
-  // Compile time assertion: sizeof(Dest) == sizeof(Source)
-  // A compile error here means your Dest and Source have different sizes.
-  typedef char VerifySizesAreEqual[sizeof(Dest) == sizeof(Source) ? 1 : -1] __attribute__((unused));
-
+  static_assert(sizeof(Dest) == sizeof(Source));
   Dest dest;
   memmove(&dest, &source, sizeof(dest));
   return dest;

--- a/double-conversion/src/double-conversion/utils.h
+++ b/double-conversion/src/double-conversion/utils.h
@@ -295,7 +295,7 @@ class StringBuilder {
 // another thus avoiding the warning.
 template <class Dest, class Source>
 inline Dest BitCast(const Source& source) {
-  static_assert(sizeof(Dest) == sizeof(Source));
+  static_assert(sizeof(Dest) == sizeof(Source), "");
   Dest dest;
   memmove(&dest, &source, sizeof(dest));
   return dest;


### PR DESCRIPTION
Because the crazy typedef doesn't work under MSVC, and `static_assert` is standardized.