### PR TITLE
Generate the proxygen headers in a windows friendly way

### DIFF
--- a/proxygen/CMakeLists.txt
+++ b/proxygen/CMakeLists.txt
@@ -13,13 +13,18 @@ list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/external/http_parser/http_p
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.cpp")
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.h")
 
+FIND_PROGRAM(GPERF_EXECUTABLE NAMES gperf)
+IF(NOT GPERF_EXECUTABLE)
+  MESSAGE(FATAL_ERROR "HHVM requires gperf for proxygen")
+ENDIF()
+
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.h
-  COMMAND HEADERS_LIST=${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.txt FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.. INSTALL_DIR=${CMAKE_CURRENT_SOURCE_DIR}/lib/http ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/gen_HTTPCommonHeaders.h.sh
+  COMMAND ${PROXYGEN_LIB_DIR}/http/gen_HTTPCommonHeaders.h.sh "${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.txt" "${CMAKE_CURRENT_SOURCE_DIR}/src" "${PROXYGEN_LIB_DIR}/http" ${GPERF_EXECUTABLE}
 )
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.cpp
-  COMMAND HEADERS_LIST=${CMAKE_CURRENT_SOURCE_DIR}/lib/http/HTTPCommonHeaders.txt FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/.. INSTALL_DIR=${CMAKE_CURRENT_SOURCE_DIR}/lib/http ${CMAKE_CURRENT_SOURCE_DIR}/lib/http/gen_HTTPCommonHeaders.cpp.sh
+  COMMAND ${PROXYGEN_LIB_DIR}/http/gen_HTTPCommonHeaders.cpp.sh "${PROXYGEN_LIB_DIR}/http/HTTPCommonHeaders.txt" "${CMAKE_CURRENT_SOURCE_DIR}/src" "${PROXYGEN_LIB_DIR}/http"
 )
 
 add_definitions(-DNO_LIB_GFLAGS)


### PR DESCRIPTION
We can't pass environment variables before the bash script when on Windows, so pass them as arguments instead.
This also allows setting a custom path for gperf, because requiring gperf to be in your path on Windows is a bit excessive.

This depends on [proxygen#55](https://github.com/facebook/proxygen/pull/55) being merged upstream first.
This also depends on [#82](https://github.com/hhvm/hhvm-third-party/pull/82), and will conflict with it as well, due to the proximity of the changes.