### PR TITLE
Don't build the kerberos utils in thrift

### DIFF
--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -44,6 +44,9 @@ foreach (file ${files})
   if (${file} MATCHES "/protocol/")
     list(REMOVE_ITEM files ${file})
   endif()
+  if (${file} MATCHES "/kerberos/")
+    list(REMOVE_ITEM files ${file})
+  endif()
 endforeach()
 
 list(REMOVE_ITEM files


### PR DESCRIPTION
Firstly, because I didn't want to deal with building them as a static library on MSVC.
And also because don't use them, and we also don't link against the kerberos libraries, so even if we did use them, it would error at link time.