### PR TITLE
Fix 'no download info for webscalesqlclient' error when building out-…

### DIFF
--- a/webscalesqlclient/CMakeLists.txt
+++ b/webscalesqlclient/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.0)
 include(ExternalProject)
 ExternalProject_Add(
   webscalesqlclient
-  SOURCE_DIR webscalesql-5.6/
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/webscalesql-5.6/
   CMAKE_ARGS
   -DWITHOUT_SERVER=TRUE
   -DDISABLE_SHARED=TRUE


### PR DESCRIPTION
…of-tree

The SOURCE_DIR option should use CMAKE_CURRENT_SOURCE_DIR when specifying the path.
For in-tree builds, the source directory is the same as the build directory. For
out-of-tree builds, the binary directory is different, so webscalesql-5.6 is not
found (hence the error).