### PR TITLE
Fixed passing of CMAKE_C_FLAGS.

### DIFF
--- a/webscalesqlclient/CMakeLists.txt
+++ b/webscalesqlclient/CMakeLists.txt
@@ -1,12 +1,13 @@
 cmake_minimum_required(VERSION 2.8.0)
 include(ExternalProject)
+SET(CMAKE_C_FLAGS "-Wno-maybe-unitialized ${CMAKE_C_FLAGS}")
 ExternalProject_Add(
   webscalesqlclient
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/webscalesql-5.6/
   CMAKE_ARGS
   -DWITHOUT_SERVER=TRUE
   -DDISABLE_SHARED=TRUE
-  -DCMAKE_C_FLAGS=-Wno-maybe-uninitialized ${CMAKE_C_FLAGS}
+  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
   -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
The space in the middle of the line meant that the originally passed in CMAKE_C_FLAGS did not get associated with the CMAKE_C_FLAGS= to the left. The end result was that no passed in flags were retained. You would only get -Wno-maybe-uninitialized. By doing the concatenation as a separate step, the right thing happens.