### PR TITLE
Don't export function in libzip

### DIFF
--- a/libzip/zipint.h
+++ b/libzip/zipint.h
@@ -40,7 +40,7 @@
 #include <zlib.h>
 
 #ifdef _WIN32
-#define ZIP_EXTERN __declspec(dllexport)
+#define ZIP_EXTERN
 /* for dup(), close(), etc. */
 #include <io.h>
 #endif


### PR DESCRIPTION
We build libzip as a static library, so the functions shouldn't be getting exported from the final binary.