### PR TITLE
update webscalesqlclient submodule to facebook/mysql-5.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "wangle/src"]
 	path = wangle/src
 	url = https://github.com/facebook/wangle
+[submodule "webscalesqlclient/mysql-5.6"]
+	path = webscalesqlclient/webscalesql-5.6
+	url = https://github.com/facebook/mysql-5.6.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,10 +13,6 @@
 [submodule "re2/src"]
 	path = re2/src
 	url = https://github.com/google/re2.git
-[submodule "webscalesqlclient/webscalesql-5.6"]
-	path = webscalesqlclient/webscalesql-5.6
-	url = https://github.com/webscalesql/webscalesql-5.6.git
-  ignore = dirty
 [submodule "squangle/squangle"]
 	path = squangle/src
 	url = https://github.com/facebook/squangle.git


### PR DESCRIPTION
Summary:
Manually changed .gitmodules then:
git submodule update --init --recursive
git pull origin webscalesql-5.6.24.97
git add webscalesqlclient
```
   hhvm-third-party/webscalesqlclient/src $ git log

   commit 896ecfc2e5d141dbab451a104c24da644ac5ea6b
   Author: Dan Reif <dreif@fb.com>
   Date:   Thu Oct 8 21:35:38 2015 -0700
```