### PR TITLE
Ensure the link order is -ljemalloc -lnuma

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -110,7 +110,11 @@ else()
   target_link_libraries(folly double-conversion)
 endif()
 
-if (JEMALLOC_ENABLED)
+# This will ensure that the _init_ in libnuma is always called first before 
+# jemalloc _init_ when the program loads.
+if (JEMALLOC_ENABLED AND LIBNUMA_ENABLED)
+  target_link_libraries(folly ${JEMALLOC_LIB} ${LIBNUMA_LIBRARIES}) 
+elseif(JEMALLOC_ENABLED)
   target_link_libraries(folly ${JEMALLOC_LIB})
 endif()
 


### PR DESCRIPTION
If NUMA build is enabled ensure the link order in -ljemalloc -lnuma, that way _init_ in libnuma is called before _init_ in libjemalloc 