### PR TITLE
Don't use symlinks for some of the MCRouter headers

### DIFF
--- a/mcrouter/CMakeLists.txt
+++ b/mcrouter/CMakeLists.txt
@@ -27,12 +27,20 @@ list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/McAsciiParser-gen.cpp")
 list(APPEND CXX_SOURCES ${files})
 
 # We need to make sure several files are the same
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/CaretReplyConverter.h"
-  "#include \"CaretReplyConverterImpl.h\"")
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/CaretSerializedMessage.h"
-  "#include \"CaretSerializedMessageImpl.h\"")
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/ServerOnRequest.h"
-  "#include \"ServerOnRequestImpl.h\"")
+macro(WRITE_IMPL_FILE dirName sourceName)
+  # These were previously symlinks, causing issues when trying to
+  # install the headers, so, if it's either a symlink, or it doesn't
+  # exist, create it.
+  if (IS_SYMLINK "${dirName}/${sourceName}.h")
+    file(REMOVE "${dirName}/${sourceName}.h")
+  endif()
+  if (NOT EXISTS "${dirName}/${sourceName}.h")
+    file(WRITE "${dirName}/${sourceName}.h" "#include \"${sourceName}Impl.h\"")
+  endif()
+endmacro()
+WRITE_IMPL_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/" "CaretReplyConverter")
+WRITE_IMPL_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/" "CaretSerializedMessage")
+WRITE_IMPL_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/" "ServerOnRequest")
 
 add_definitions(-DNO_LIB_GFLAGS)
 add_definitions(-DLIBMC_FBTRACE_DISABLE)

--- a/mcrouter/CMakeLists.txt
+++ b/mcrouter/CMakeLists.txt
@@ -26,25 +26,13 @@ endforeach()
 list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/McAsciiParser-gen.cpp")
 list(APPEND CXX_SOURCES ${files})
 
-# We need to create several symlinks.
-execute_process(
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/"
-  COMMAND ln -s
-    "CaretReplyConverterImpl.h"
-    "CaretReplyConverter.h"
-)
-execute_process(
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/"
-  COMMAND ln -s
-    "CaretSerializedMessageImpl.h"
-    "CaretSerializedMessage.h"
-)
-execute_process(
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/"
-  COMMAND ln -s
-    "ServerOnRequestImpl.h"
-    "ServerOnRequest.h"
-)
+# We need to make sure several files are the same
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/CaretReplyConverter.h"
+  "#include \"CaretReplyConverterImpl.h\"")
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/CaretSerializedMessage.h"
+  "#include \"CaretSerializedMessageImpl.h\"")
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/ServerOnRequest.h"
+  "#include \"ServerOnRequestImpl.h\"")
 
 add_definitions(-DNO_LIB_GFLAGS)
 add_definitions(-DLIBMC_FBTRACE_DISABLE)


### PR DESCRIPTION
This causes issues for some as `file(COPY)` doesn't work on symlinks, and doing that under windows is just a pain.
This just writes a file which directly includes the target of the symlink instead.

This should fix [HHVM #6532](https://github.com/facebook/hhvm/issues/6532).