### PR TITLE
Removed unused CaretReplyConverter.h.

### DIFF
--- a/mcrouter/CMakeLists.txt
+++ b/mcrouter/CMakeLists.txt
@@ -57,7 +57,6 @@ macro(WRITE_IMPL_FILE dirName sourceName)
     file(WRITE "${dirName}/${sourceName}.h" "#include \"${sourceName}Impl.h\"")
   endif()
 endmacro()
-WRITE_IMPL_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/" "CaretReplyConverter")
 WRITE_IMPL_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/lib/network/" "CaretSerializedMessage")
 WRITE_IMPL_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mcrouter/" "ServerOnRequest")
 


### PR DESCRIPTION
mcrouter no longer uses CaretReplyConverter.h. I've removed its creation from the cmake files so that git status does not report the file as a new untracked file.