### PR TITLE
Fix compiler warnings

### DIFF
--- a/libmbfl/filters/mbfilter_big5.c
+++ b/libmbfl/filters/mbfilter_big5.c
@@ -192,7 +192,7 @@ mbfl_filt_conv_big5_wchar(int c, mbfl_convert_filter *filter)
 					 && ((c > 0x39 && c < 0x7f) || (c > 0xa0 && c < 0xff))) ||
 					((c1 == 0xc6) && (c > 0xa0 && c < 0xff))) {
 					c2 = c1 << 8 | c;
-					for (k = 0; k < sizeof(cp950_pua_tbl)/(sizeof(unsigned short)*4); k++) {
+					for (k = 0; k < (int)(sizeof(cp950_pua_tbl)/(sizeof(unsigned short)*4)); k++) {
 						if (c2 >= cp950_pua_tbl[k][2] && c2 <= cp950_pua_tbl[k][3]) {
 							break;
 						}
@@ -259,7 +259,7 @@ mbfl_filt_conv_wchar_big5(int c, mbfl_convert_filter *filter)
 
 	if (filter->to->no_encoding == mbfl_no_encoding_cp950) {
 		if (c >= 0xe000 && c <= 0xf848) { /* PUA for CP950 */
-			for (k = 0; k < sizeof(cp950_pua_tbl)/(sizeof(unsigned short)*4); k++) {
+			for (k = 0; k < (int)(sizeof(cp950_pua_tbl)/(sizeof(unsigned short)*4)); k++) {
 				if (c <= cp950_pua_tbl[k][1]) {
 					break;
 				}

--- a/ragel/src/ragel/fsmbase.cpp
+++ b/ragel/src/ragel/fsmbase.cpp
@@ -507,7 +507,9 @@ void FsmAp::depthFirstOrdering()
 		st->stateBits &= ~STB_ONLIST;
 	
 	/* Clear out the state list, we will rebuild it. */
+#ifdef DEBUG
 	int stateListLen = stateList.length();
+#endif
 	stateList.abandon();
 
 	/* Add back to the state list from the start state and all other entry

--- a/ragel/src/ragel/redfsm.cpp
+++ b/ragel/src/ragel/redfsm.cpp
@@ -100,7 +100,9 @@ void RedFsmAp::depthFirstOrdering()
 		st->onStateList = false;
 	
 	/* Clear out the state list, we will rebuild it. */
+#ifdef DEBUG
 	int stateListLen = stateList.length();
+#endif
 	stateList.abandon();
 
 	/* Add back to the state list from the start state and all other entry
@@ -513,8 +515,7 @@ RedTransAp *RedFsmAp::getErrorTrans( )
 		/* This insert should always succeed since no transition created by
 		 * the user can point to the error state. */
 		errTrans = new RedTransAp( getErrorState(), 0, nextTransId++ );
-		RedTransAp *inRes = transSet.insert( errTrans );
-		assert( inRes != 0 );
+    if ( transSet.insert( errTrans ) == 0 ) assert(false);
 	}
 	return errTrans;
 }

--- a/timelib/parse_date.re
+++ b/timelib/parse_date.re
@@ -175,17 +175,17 @@ typedef struct _timelib_relunit {
 } timelib_relunit;
 
 /* The timezone table. */
-const static timelib_tz_lookup_table timelib_timezone_lookup[] = {
+static const timelib_tz_lookup_table timelib_timezone_lookup[] = {
 #include "timezonemap.h"
 	{ NULL, 0, 0, NULL },
 };
 
-const static timelib_tz_lookup_table timelib_timezone_fallbackmap[] = {
+static const timelib_tz_lookup_table timelib_timezone_fallbackmap[] = {
 #include "fallbackmap.h"
 	{ NULL, 0, 0, NULL },
 };
 
-const static timelib_tz_lookup_table timelib_timezone_utc[] = {
+static const timelib_tz_lookup_table timelib_timezone_utc[] = {
 	{ "utc", 0, 0, "UTC" },
 };
 
@@ -674,7 +674,7 @@ static void timelib_set_relative(char **ptr, timelib_sll amount, int behavior, S
 	}
 }
 
-const static timelib_tz_lookup_table* abbr_search(const char *word, timelib_long gmtoffset, int isdst)
+static const timelib_tz_lookup_table* abbr_search(const char *word, timelib_long gmtoffset, int isdst)
 {
 	int first_found = 0;
 	const timelib_tz_lookup_table  *tp, *first_found_elem = NULL;


### PR DESCRIPTION
- signed vs unsigned comparison
- unused variable (variables were only used for asserts, and I was
  compiling a release version)
- static should be prior to const modifier