### PR TITLE
ocaml: Disable parallel build.

### DIFF
--- a/ocaml/CMakeLists.txt
+++ b/ocaml/CMakeLists.txt
@@ -33,7 +33,7 @@ if (NOT OCAMLC_FOUND)
   add_custom_command(
     OUTPUT ${OCAMLC} ${OCAMLOPT}
     COMMAND ./configure -prefix "${OCAML_PREFIX}" -no-graph
-    COMMAND \$\(MAKE\) world.opt
+    COMMAND \$\(MAKE\) -j1 world.opt
     COMMAND \$\(MAKE\) install
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
     COMMENT "Compiling ocaml")


### PR DESCRIPTION
At least on multicore arm64 machines (>= 8 cores)
the parallel build of ocaml is broken.

This patch addresses this issue by disabling the parallel build.

See https://github.com/facebook/hhvm/issues/7611

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>