### PR TITLE
Don't explicitly disable the maybe-unused warning for webscalemysql

### DIFF
--- a/webscalesqlclient/CMakeLists.txt
+++ b/webscalesqlclient/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.0)
 include(ExternalProject)
-SET(CMAKE_C_FLAGS "-Wno-maybe-uninitialized ${CMAKE_C_FLAGS}")
 ExternalProject_Add(
   webscalesqlclient
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/


### PR DESCRIPTION
Let HPHPCompiler deal with it for us. The `maybe-unused` warning also doesn't exist on clang 3.6, so was spamming the build output.

Depends on internal diff D4663382.