### PR TITLE
LZ4_LIBRARY -> LZ4_FOUND

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if(NOT LIBSQLITE3_LIBRARY)
 endif()
 
 # Add bundled lz4 if the system one will not be used
-if(NOT LZ4_LIBRARY)
+if(NOT LZ4_FOUND)
   list(APPEND THIRD_PARTY_MODULES lz4)
   list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/lz4/src/lib")
 endif()


### PR DESCRIPTION
This fixes the case where we find an lz4 library installed, but it is not a supported version.  See https://github.com/facebook/hhvm/issues/7804