### PR TITLE
Fix TravisCI build fail due to missing reference

### DIFF
--- a/util/make-notices.hh
+++ b/util/make-notices.hh
@@ -85,7 +85,7 @@ final class ThirdPartyBinaryNotices {
       $projects[] = $project;
     }
 
-    sort($projects);
+    sort(&$projects);
     foreach ($projects as $project) {
       $config = $known_projects[$project] ?? null;
       if ($config === null) {


### PR DESCRIPTION
Fixes https://github.com/hhvm/hhvm-third-party/issues/125. HHVM 3.24 requires the reference arguments to be marked at the call site, making the TravisCI build for third-party to fail due to a missing reference when calling the "sort" function.

This change fixes this issue by marking the argument of "sort" as a reference at the call site.