### PR TITLE
Always build OCaml

### DIFF
--- a/ocaml/CMakeLists.txt
+++ b/ocaml/CMakeLists.txt
@@ -1,81 +1,56 @@
-# Phase 1 - see if they have a built-in version of ocamlc which is 'good enough'
-find_program(OCAML NAMES ocaml ocaml)
-find_program(OCAMLC NAMES ocamlc.opt ocamlc)
-find_program(OCAMLOPT NAMES ocamlopt.opt ocamlopt)
-find_program(OCAMLBUILD NAMES ocamlbuild.native ocamlbuild)
+# Either we couldn't find a reasonable version of ocamlc or it was too old.
+message(STATUS "Building ocaml from third-party")
 
-set(OCAMLC_FOUND FALSE)
+set(OCAML_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build")
+set(OCAML "${OCAML_PREFIX}/bin/ocaml")
+set(OCAMLC "${OCAML_PREFIX}/bin/ocamlc.opt")
+set(OCAMLOPT "${OCAML_PREFIX}/bin/ocamlopt.opt")
+set(OCAMLBUILD "${OCAML_PREFIX}/bin/ocamlbuild.native")
+set(OPAM "${OCAML_PREFIX}/bin/opam")
 
-if (OCAMLC)
-  # We found a local version of ocamlc - check the version.
-  message(STATUS "Found ocamlc: ${OCAMLC}")
-  execute_process(COMMAND "${OCAMLC}" -version
-    OUTPUT_VARIABLE OCAMLC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+# TODO: what about dependencies so we rebuild ocaml when it changes?
+# NOTE: The weirdness building world.opt twice is because (at least on arm64)
+# ocaml (4.03) seems to have parallel build dependency problems.
+add_custom_command(
+  OUTPUT ${OCAML} ${OCAMLC} ${OCAMLOPT}
+  COMMAND ./configure -prefix "${OCAML_PREFIX}" -no-graph
+  COMMAND \$\(MAKE\) -k world.opt || true
+  COMMAND \$\(MAKE\) -j1 world.opt
+  COMMAND \$\(MAKE\) install
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  COMMENT "Compiling ocaml")
 
-  message(STATUS "Got ocaml version ${OCAMLC_VERSION}")
-  if ("${OCAMLC_VERSION}" VERSION_LESS "4.03")
-    message(STATUS "System version of ocaml is too old")
-  else()
-    set(OCAMLC_FOUND TRUE)
-  endif()
-endif()
+add_custom_command(
+  OUTPUT ${OCAMLBUILD}
+  # Hack up the path before building ocamlbuild.
+  # (OCamlBuild doesn't understand how to override its build tools properly -
+  # they call "ocamlc -where" directly from configure.make)
+  # This would be better as 'cmake -E env' but that's only available in cmake 3.1+
+  COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\) -f configure.make
+      OCAML_NATIVE=true
+      OCAMLBUILD_BINDIR=${OCAML_PREFIX}/bin
+      OCAMLBUILD_LIBDIR=${OCAML_PREFIX}/lib'
+  COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\)'
+  COMMAND \$\(MAKE\) install CHECK_IF_PREINSTALLED=false
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ocamlbuild"
+  DEPENDS ${OCAMLC}
+  COMMENT "Compiling ocamlbuild")
 
-if (NOT OCAMLC_FOUND)
-  # Either we couldn't find a reasonable version of ocamlc or it was too old.
-  message(STATUS "Building ocaml from third-party")
+add_custom_command(
+  OUTPUT ${OPAM}
+  COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" ./configure --prefix="${OCAML_PREFIX}"'
+  # prep source tree to skip the %.download and %.stamp Makefile rules of lib-ext
+  COMMAND /bin/bash -c '${CMAKE_CURRENT_SOURCE_DIR}/opam_deps/prep_deps.sh ${OCAML_PREFIX} ${CMAKE_CURRENT_SOURCE_DIR}/opam_deps ./src_ext'
+  COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\) -j1 lib-ext'
+  COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\) -j1'
+  COMMAND \$\(MAKE\) install
+  # ensure clean git status
+  COMMAND /bin/bash -c '${CMAKE_CURRENT_SOURCE_DIR}/opam_deps/cleanup_src_ext.sh ./src_ext'
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/opam"
+  DEPENDS ${OCAMLBUILD}
+  COMMENT "Compiling opam")
 
-  set(OCAML_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build")
-  set(OCAML "${OCAML_PREFIX}/bin/ocaml")
-  set(OCAMLC "${OCAML_PREFIX}/bin/ocamlc.opt")
-  set(OCAMLOPT "${OCAML_PREFIX}/bin/ocamlopt.opt")
-  set(OCAMLBUILD "${OCAML_PREFIX}/bin/ocamlbuild.native")
-  set(OPAM "${OCAML_PREFIX}/bin/opam")
-
-  # TODO: what about dependencies so we rebuild ocaml when it changes?
-  # NOTE: The weirdness building world.opt twice is because (at least on arm64)
-  # ocaml (4.03) seems to have parallel build dependency problems.
-  add_custom_command(
-    OUTPUT ${OCAML} ${OCAMLC} ${OCAMLOPT}
-    COMMAND ./configure -prefix "${OCAML_PREFIX}" -no-graph
-    COMMAND \$\(MAKE\) -k world.opt || true
-    COMMAND \$\(MAKE\) -j1 world.opt
-    COMMAND \$\(MAKE\) install
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    COMMENT "Compiling ocaml")
-
-  add_custom_command(
-    OUTPUT ${OCAMLBUILD}
-    # Hack up the path before building ocamlbuild.
-    # (OCamlBuild doesn't understand how to override its build tools properly -
-    # they call "ocamlc -where" directly from configure.make)
-    # This would be better as 'cmake -E env' but that's only available in cmake 3.1+
-    COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\) -f configure.make
-        OCAML_NATIVE=true
-        OCAMLBUILD_BINDIR=${OCAML_PREFIX}/bin
-        OCAMLBUILD_LIBDIR=${OCAML_PREFIX}/lib'
-    COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\)'
-    COMMAND \$\(MAKE\) install CHECK_IF_PREINSTALLED=false
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ocamlbuild"
-    DEPENDS ${OCAMLC}
-    COMMENT "Compiling ocamlbuild")
-
-  add_custom_command(
-    OUTPUT ${OPAM}
-    COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" ./configure --prefix="${OCAML_PREFIX}"'
-    # prep source tree to skip the %.download and %.stamp Makefile rules of lib-ext
-    COMMAND /bin/bash -c '${CMAKE_CURRENT_SOURCE_DIR}/opam_deps/prep_deps.sh ${OCAML_PREFIX} ${CMAKE_CURRENT_SOURCE_DIR}/opam_deps ./src_ext'
-    COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\) -j1 lib-ext'
-    COMMAND /bin/bash -c 'PATH="${OCAML_PREFIX}/bin:$ENV{PATH}" \$\(MAKE\) -j1'
-    COMMAND \$\(MAKE\) install
-    # ensure clean git status
-    COMMAND /bin/bash -c '${CMAKE_CURRENT_SOURCE_DIR}/opam_deps/cleanup_src_ext.sh ./src_ext'
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/opam"
-    DEPENDS ${OCAMLBUILD}
-    COMMENT "Compiling opam")
-
-  set(OCAMLC_FOUND TRUE)
-endif()
+set(OCAMLC_FOUND TRUE)
 
 add_custom_target(ocaml
   DEPENDS ${OCAMLC} ${OCAMLOPT} ${OCAMLBUILD} ${OPAM})


### PR DESCRIPTION
Even if it's the right version, it's never usable with the new
opam-based build system.