### PR TITLE
Fix opam2 build dependecies

### DIFF
--- a/ocaml/CMakeLists.txt
+++ b/ocaml/CMakeLists.txt
@@ -71,7 +71,7 @@ add_custom_command(
     \$\(MAKE\) install \
   "
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/opam"
-  DEPENDS ${OPAM_SRC}
+  DEPENDS ${OPAM_SRC} ${OCAMLC}
   COMMENT "Compiling opam")
 
 set(OCAMLC_FOUND TRUE)


### PR DESCRIPTION
opam2 still needs ocaml binaries to be built (next PR will remove
this). So we still need to make the 'opam' target depend on 'ocamlc'

Without this fix, aggressive parallel build might fail when trying to compile opam while ocaml is not build yet.

Sorry about that :D