### PR TITLE
'opam' CMake target to prepare for ocaml removal

### DIFF
--- a/ocaml/CMakeLists.txt
+++ b/ocaml/CMakeLists.txt
@@ -79,6 +79,10 @@ set(OCAMLC_FOUND TRUE)
 add_custom_target(ocaml
   DEPENDS ${OCAMLC} ${OCAMLOPT} ${OCAMLBUILD} ${OPAM})
 
+add_custom_target(opam
+    DEPENDS ocaml
+)
+
 set(OCAML_EXECUTABLE ${OCAML} CACHE FILEPATH "path to ocaml" FORCE)
 mark_as_advanced(OCAML_EXECUTABLE)
 set(OCAMLC_EXECUTABLE ${OCAMLC} CACHE FILEPATH "path to ocamlc" FORCE)


### PR DESCRIPTION
Opam can be built without ocaml, there is a sandboxing mechanism.
In order to get rid of ocaml, we need to make hhvm depend on opam,
not on ocaml.

This patch adds a new opam target for this purpose. Once this is done,
hhvm can be updated to only depend on opam information. Once this is
done, ocaml can be stripped from third-party