### PR TITLE
Don't build rsocket + thrift rsocket support if OpenSSL is too old

### DIFF
--- a/rsocket-cpp/CMakeLists.txt
+++ b/rsocket-cpp/CMakeLists.txt
@@ -2,9 +2,14 @@ cmake_minimum_required(VERSION 2.8.0)
 
 set(RSOCKET_CPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-# Main rsocket_cpp library files
-auto_sources(files "*.cpp" "RECURSE" "${RSOCKET_CPP_DIR}")
-auto_sources(hfiles "*.h" "RECURSE" "${RSOCKET_CPP_DIR}")
+if (OPENSSL_HAVE_ALPN)
+  # Main rsocket_cpp library files
+  auto_sources(files "*.cpp" "RECURSE" "${RSOCKET_CPP_DIR}")
+  auto_sources(hfiles "*.h" "RECURSE" "${RSOCKET_CPP_DIR}")
+else()
+  auto_sources(files "*.cpp" "RECURSE" "${RSOCKET_CPP_DIR}/yarpl")
+  auto_sources(hfiles "*.h" "RECURSE" "${RSOCKET_CPP_DIR}/yarpl")
+endif()
 
 HHVM_REMOVE_MATCHES_FROM_LISTS(files hfiles MATCHES "/devtools/" "/benchmarks/" "/examples/" "/test/" "/perf/")
 

--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -38,6 +38,15 @@ list(REMOVE_ITEM files
   ${THRIFT_DIR}/lib/cpp/util/TNonblockingServerCreator.cpp
 )
 
+if (NOT OPENSSL_HAVE_ALPN)
+  HHVM_REMOVE_MATCHES_FROM_LISTS(files MATCHES
+    "/lib/cpp2/transport/rsocket/"
+    "/lib/cpp2/transport/rocket/"
+    ".*/RSocket.*"
+    ".*/Rocket.*"
+  )
+endif()
+
 list(APPEND CXX_SOURCES ${files})
 
 auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}/gen")


### PR DESCRIPTION
Needs an HHVM diff to CMake too.

Always build rsocket-cpp/yarpl - a reactive programming library - as
Thrift always depends on it, even if not being built with full rsocket
support.